### PR TITLE
コメンテータ未定の時に対応

### DIFF
--- a/listPresentations.py
+++ b/listPresentations.py
@@ -22,10 +22,10 @@ def generatePresentationInfo(room,sessionID,paperID,presenOrder,papers,slots):
 
 # main procedure
 if __name__ == '__main__':
-    data_papers = 'http://cms.deim-forum.org/deim2016/list/papers.php?decode&pretty&jsonp=callback'
+    data_papers = 'http://cms.deim-forum.org/deim2017/list/papers.php?decode&pretty&jsonp=callback'
     papers = deim.getPaperInfo(data_papers)
 
-    data_program = 'http://db-event.jpn.org/deim2016/data_program.js'
+    data_program = 'http://db-event.jpn.org/deim2017/data_program.js'
     program = deim.loadProgramInfo(data_program,'var sessions =')
     slots = deim.getSlotInfo(program)
     

--- a/listSessions.py
+++ b/listSessions.py
@@ -2,31 +2,40 @@
 
 import deim
 
+# フラグ：座長とコメンテータが決まってる時は1
+reviewer_assigned = 0
+# コメンテータの数
+nofreviewers = 2
+
 # セッション情報を生成する（PosTom用)
 def generateSessionInfo(room,sessionID,sinfo,reviewer):
     session = [room,sessionID,sinfo["title"]]
     session.extend([str(slots[sessionID]["day"]),slots[sessionID]["start"],slots[sessionID]["end"]])
-    chair = reviewer["reviewers"][sinfo["chair"]]
-    session.append(chair["name_last"]+" "+chair["name_first"])
-    if chair["organization_abbr"] :
-        session.append(chair["organization_abbr"])
-    else:
-        session.append(chair["organization"])
-    comms = [reviewer["reviewers"][sinfo["comm1"]],reviewer["reviewers"][sinfo["comm2"]]]
-    names = []; affrs = []
-    for comm in comms:
-        names.append(comm["name_last"]+" "+comm["name_first"])
-        if(comm["organization_abbr"]):
-            affrs.append(comm["organization_abbr"])
+    if reviewer_assigned == 1:
+        chair = reviewer["reviewers"][sinfo["chair"]]
+        session.append(chair["name_last"]+" "+chair["name_first"])
+        if chair["organization_abbr"] :
+            session.append(chair["organization_abbr"])
         else:
-            affrs.append(comm["organization"])
-    session.extend(['"'+",".join(names)+'"','"'+",".join(affrs)+'"'])
+            session.append(chair["organization"])
+        comms = [reviewer["reviewers"][sinfo["comm1"]],reviewer["reviewers"][sinfo["comm2"]]]
+        names = []; affrs = []
+        for comm in comms:
+            names.append(comm["name_last"]+" "+comm["name_first"])
+            if(comm["organization_abbr"]):
+                affrs.append(comm["organization_abbr"])
+            else:
+                affrs.append(comm["organization"])
+        session.extend(['"'+",".join(names)+'"','"'+",".join(affrs)+'"'])
+    else:
+        for i in range(1, nofreviewers+1):
+            session.extend(["TBD","TBD"])
     return session
 
 # main procedure
 if __name__ == '__main__':
-    data_program = 'http://db-event.jpn.org/deim2016/data_program.js'
-    data_reviewer = 'http://db-event.jpn.org/deim2016/data_reviewers.js'
+    data_program = 'http://db-event.jpn.org/deim2017/data_program.js'
+    data_reviewer = 'http://db-event.jpn.org/deim2017/data_reviewers.js'
 
     program = deim.loadProgramInfo(data_program,'var sessions =')
     reviewer = deim.loadProgramInfo(data_reviewer,'var reviewers =')


### PR DESCRIPTION
#3 に対応したもの。
deim2017のデータを見ると、コメンテータ情報は去年のものが残ってて、
座長とコメンテータがTBDというのはハードコーディングされていたので、
プログラムではTBDは検出不可能でした。

というわけで reviewer_assigned というフラグを用意して
そのフラグが0の時は座長とコメンテータは強制的にTBDにするようにしましたw